### PR TITLE
Fix syntax error

### DIFF
--- a/lib/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -39,7 +39,7 @@ class LanguageServerWorseReflectionExtension implements Extension
 
         $container->register(WorkspaceIndexListener::class, function (Container $container) {
             return new WorkspaceIndexListener(
-                $container->get(WorkspaceIndex::class),
+                $container->get(WorkspaceIndex::class)
             );
         }, [ LanguageServerExtension::TAG_LISTENER_PROVIDER => [] ]);
 


### PR DESCRIPTION
```
Phpactor returned an error: PHP Parse error:  syntax error, unexpected ')' in /home/oleg/.vim/plugged/phpactor/vendor/phpactor/language-server-extension/lib/L
anguageServerWorseReflection/LanguageServerWorseReflectionExtension.php on line 43
Parse error: syntax error, unexpected ')' in /home/oleg/.vim/plugged/phpactor/vendor/phpactor/language-server-extension/lib/LanguageServerWorseReflection/Lang
uageServerWorseReflectionExtension.php on line 43
```