### PR TITLE
Fix order references

### DIFF
--- a/lib/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
+++ b/lib/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
@@ -161,18 +161,7 @@ class ReferencesHandler implements Handler, CanRegisterCapabilities
      */
     private function toLocations(array $locations): array
     {
-        usort($locations, function (Location $first, Location $second) {
-            $order = strcmp((string) $first->uri(), (string) $second->uri());
-            if (0 !== $order) {
-                return $order;
-            }
-
-            return $first->offset()->toInt() - $second->offset()->toInt();
-        });
-
-        $lspLocations = $this->locationConverter->toLspLocations(new Locations($locations));
-
-        return $lspLocations;
+        return $this->locationConverter->toLspLocations(Locations::bySorting($locations));
     }
 
     public function registerCapabiltiies(ServerCapabilities $capabilities): void

--- a/lib/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
+++ b/lib/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
@@ -161,7 +161,9 @@ class ReferencesHandler implements Handler, CanRegisterCapabilities
      */
     private function toLocations(array $locations): array
     {
-        return $this->locationConverter->toLspLocations(Locations::bySorting($locations));
+        return $this->locationConverter->toLspLocations(
+            (new Locations($locations))->sorted()
+        );
     }
 
     public function registerCapabiltiies(ServerCapabilities $capabilities): void

--- a/lib/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
+++ b/lib/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
@@ -161,7 +161,18 @@ class ReferencesHandler implements Handler, CanRegisterCapabilities
      */
     private function toLocations(array $locations): array
     {
-        return $this->locationConverter->toLspLocations(new Locations($locations));
+        usort($locations, function (Location $first, Location $second) {
+            $order = strcmp((string) $first->uri(), (string) $second->uri());
+            if (0 !== $order) {
+                return $order;
+            }
+
+            return $first->offset()->toInt() - $second->offset()->toInt();
+        });
+
+        $lspLocations = $this->locationConverter->toLspLocations(new Locations($locations));
+
+        return $lspLocations;
     }
 
     public function registerCapabiltiies(ServerCapabilities $capabilities): void

--- a/tests/LanguageServerReferenceFinder/Unit/Handler/ReferencesHandlerTest.php
+++ b/tests/LanguageServerReferenceFinder/Unit/Handler/ReferencesHandlerTest.php
@@ -31,12 +31,12 @@ class ReferencesHandlerTest extends TestCase
     const EXAMPLE_TEXT = 'hello';
 
     /**
-     * @var ObjectProphecy|ReferenceFinder
+     * @var ObjectProphecy<ReferenceFinder>
      */
     private $finder;
 
     /**
-     * @var ObjectProphecy
+     * @var ObjectProphecy<DefinitionLocator>
      */
     private $locator;
 
@@ -116,7 +116,7 @@ class ReferencesHandlerTest extends TestCase
             ByteOffset::fromInt(0)
         )->willReturn(new DefinitionLocation($document->uri(), ByteOffset::fromInt(2)))->shouldBeCalled();
 
-        $response = $this->createTester(true)->requestAndWait(ReferencesRequest::METHOD, [
+        $response = $this->createTester()->requestAndWait(ReferencesRequest::METHOD, [
             'textDocument' => ProtocolFactory::textDocumentIdentifier(self::EXAMPLE_URI),
             'position' => ProtocolFactory::position(0, 0),
             'context' => new ReferenceContext(true),
@@ -128,7 +128,7 @@ class ReferencesHandlerTest extends TestCase
         $this->assertInstanceOf(LspLocation::class, $lspLocation);
     }
 
-    public function testFindsReferencesIncludingDeclarationWhenDeclarationNotFound()
+    public function testFindsReferencesIncludingDeclarationWhenDeclarationNotFound(): void
     {
         $document = TextDocumentBuilder::create(self::EXAMPLE_TEXT)
             ->language('php')


### PR DESCRIPTION
Order the result of the find references feature.
Fix https://github.com/phpactor/phpactor/issues/1105

Depends on https://github.com/phpactor/text-document/pull/7 in this current implementation.