### PR TITLE
fix completion result isComplete

### DIFF
--- a/lib/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -98,6 +98,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
             );
 
             $items = [];
+            $isIncomplete = false;
             foreach ($suggestions as $suggestion) {
                 $name = $this->suggestionNameFormatter->format($suggestion);
                 $insertText = $name;
@@ -125,12 +126,15 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
                 try {
                     $token->throwIfRequested();
                 } catch (CancelledException $cancellation) {
+                    $isIncomplete = true;
                     break;
                 }
                 yield new Delayed(0);
             }
 
-            return new CompletionList(true, $items);
+            $isIncomplete = $isIncomplete || !$suggestions->getReturn();
+
+            return new CompletionList($isIncomplete, $items);
         });
     }
 


### PR DESCRIPTION
Update from an old PR on the previous repository: https://github.com/phpactor/language-server-extension/pull/8

Currently we always return that the completion list is incomplete.
The PR use the return of the completor to define it in order for a client to be able to avoid unnecessary requests.