### PR TITLE
Optimize workspace update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tests/*/Workspace
 /composer.lock
 /.php_cs.cache
+/.phpbench

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "friendsofphp/php-cs-fixer": "^2.17",
         "jangregor/phpstan-prophecy": "^0.8.0",
         "phpactor/test-utils": "^1.1",
-        "phpbench/phpbench": "^1.0.0-alpha3",
+        "phpbench/phpbench": "^1.0.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "~0.12.0",
         "phpunit/phpunit": "^9.0",

--- a/lib/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -15,6 +15,8 @@ use Phpactor\WorseReflection\ReflectorBuilder;
 
 class LanguageServerWorseReflectionExtension implements Extension
 {
+    const PARAM_UPDATE_INTERVAL = 'language_server_worse_reflection.workspace_index.update_interval';
+
     /**
      * {@inheritDoc}
      */
@@ -25,6 +27,12 @@ class LanguageServerWorseReflectionExtension implements Extension
 
     public function configure(Resolver $schema)
     {
+        $schema->setDefaults([
+            self::PARAM_UPDATE_INTERVAL => 100,
+        ]);
+        $schema->setDescriptions([
+            self::PARAM_UPDATE_INTERVAL => 'Minimum interval to update the workspace index as documents are updated (in milliseconds)'
+        ]);
     }
 
     private function registerSourceLocator(ContainerBuilder $container): void
@@ -45,7 +53,8 @@ class LanguageServerWorseReflectionExtension implements Extension
 
         $container->register(WorkspaceIndex::class, function (Container $container) {
             return new WorkspaceIndex(
-                ReflectorBuilder::create()->build()
+                ReflectorBuilder::create()->build(),
+                $container->getParameter(self::PARAM_UPDATE_INTERVAL)
             );
         });
     }

--- a/phpbench.json
+++ b/phpbench.json
@@ -3,7 +3,5 @@
     "path": [
         "tests/LanguageServerCodeTransform/Benchmark",
         "tests/LanguageServerWorseReflection/Benchmark"
-    ],
-    "remote_script_path": ".phpbench/script",
-    "remote_script_remove": false
+    ]
 }

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,4 +1,9 @@
 {
     "bootstrap": "vendor/autoload.php",
-    "path": "tests/LanguageServerCodeTransform/Benchmark"
+    "path": [
+        "tests/LanguageServerCodeTransform/Benchmark",
+        "tests/LanguageServerWorseReflection/Benchmark"
+    ],
+    "remote_script_path": ".phpbench/script",
+    "remote_script_remove": false
 }

--- a/tests/LanguageServerCompletion/IntegrationTestCase.php
+++ b/tests/LanguageServerCompletion/IntegrationTestCase.php
@@ -52,7 +52,7 @@ class IntegrationTestCase extends TestCase
 
             LanguageServerBridgeExtension::class,
         ], [
-            FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ .'/../../'
+            FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ .'/../../',
         ]);
         
         $builder = $container->get(LanguageServerBuilder::class);

--- a/tests/LanguageServerWorseReflection/Benchmark/WorkspaceIndexBench.php
+++ b/tests/LanguageServerWorseReflection/Benchmark/WorkspaceIndexBench.php
@@ -25,11 +25,13 @@ class WorkspaceIndexBench extends IntegrationTestCase
     public function setUp(): void
     {
         $this->tester = $this->createTester();
+        $this->tester->initialize();
+        $this->tester->textDocument()->open('file:///foobar', '');
     }
 
     /**
      * @ParamProviders({"provideUpdate"})
-     * @Revs(100)
+     * @Revs(10)
      * @Iterations(10)
      */
     public function benchUpdate(array $params): void

--- a/tests/LanguageServerWorseReflection/Benchmark/WorkspaceIndexBench.php
+++ b/tests/LanguageServerWorseReflection/Benchmark/WorkspaceIndexBench.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerWorseReflection\Tests\Benchmark;
+
+use PhpBench\Benchmark\Metadata\Annotations\Executor;
+use PhpBench\Benchmark\Metadata\Annotations\OutputTimeUnit;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use Phpactor\Extension\LanguageServerCompletion\Tests\IntegrationTestCase;
+use Phpactor\LanguageServer\Test\LanguageServerTester;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use Generator;
+
+/**
+ * @BeforeMethods({"setUp"})
+ * @OutputTimeUnit("milliseconds")
+ * @Executor("local")
+ */
+class WorkspaceIndexBench extends IntegrationTestCase
+{
+    /**
+     * @var LanguageServerTester
+     */
+    private $tester;
+
+    public function setUp(): void
+    {
+        $this->tester = $this->createTester();
+    }
+
+    /**
+     * @ParamProviders({"provideUpdate"})
+     * @Revs(100)
+     * @Iterations(10)
+     */
+    public function benchUpdate(array $params): void
+    {
+        $this->tester->textDocument()->update('file:///foobar', $params['text']);
+    }
+
+    public function provideUpdate(): Generator
+    {
+        $source = mb_str_split((string)file_get_contents(
+            __DIR__ . '/source/source.php.example'
+        ), 1);
+
+        $buffer = '';
+
+        foreach ($source as $index => $char) {
+            $buffer .= $char;
+            if (0 === $index % 1000) {
+                yield 'length: ' . strlen($buffer) => [
+                    'text' => $buffer
+                ];
+            }
+        }
+    }
+}

--- a/tests/LanguageServerWorseReflection/Benchmark/source/source.php.example
+++ b/tests/LanguageServerWorseReflection/Benchmark/source/source.php.example
@@ -1,0 +1,193 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerHover\Handler;
+
+use Amp\Promise;
+use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
+use Phpactor\LanguageServerProtocol\Hover;
+use Phpactor\LanguageServerProtocol\MarkupContent;
+use Phpactor\LanguageServerProtocol\Position;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\ServerCapabilities;
+use Phpactor\LanguageServerProtocol\TextDocumentIdentifier;
+use Phpactor\Completion\Core\Exception\CouldNotFormat;
+use Phpactor\Extension\LanguageServerHover\Renderer\HoverInformation;
+use Phpactor\Extension\LanguageServerHover\Renderer\MemberDocblock;
+use Phpactor\LanguageServer\Core\Handler\CanRegisterCapabilities;
+use Phpactor\LanguageServer\Core\Handler\Handler;
+use Phpactor\LanguageServer\Core\Workspace\Workspace;
+use Phpactor\ObjectRenderer\Model\ObjectRenderer;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Core\Exception\NotFound;
+use Phpactor\WorseReflection\Core\Inference\Symbol;
+use Phpactor\WorseReflection\Core\Inference\SymbolContext;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionOffset;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Reflector;
+
+class HoverHandler implements Handler, CanRegisterCapabilities
+{
+    /**
+     * @var Reflector
+     */
+    private $reflector;
+
+    /**
+     * @var ObjectRenderer
+     */
+    private $renderer;
+
+    /**
+     * @var Workspace
+     */
+    private $workspace;
+
+    public function __construct(Workspace $workspace, Reflector $reflector, ObjectRenderer $renderer)
+    {
+        $this->reflector = $reflector;
+        $this->renderer = $renderer;
+        $this->workspace = $workspace;
+    }
+
+    public function methods(): array
+    {
+        return [
+            'textDocument/hover' => 'hover',
+        ];
+    }
+
+    public function hover(
+        TextDocumentIdentifier $textDocument,
+        Position $position
+    ): Promise {
+        return \Amp\call(function () use ($textDocument, $position) {
+            $document = $this->workspace->get($textDocument->uri);
+            $offset = PositionConverter::positionToByteOffset($position, $document->text);
+            $document = TextDocumentBuilder::create($document->text)
+                ->uri($document->uri)
+                ->language('php')
+                ->build();
+
+            $offsetReflection = $this->reflector->reflectOffset($document, $offset);
+            $symbolContext = $offsetReflection->symbolContext();
+            $info = $this->infoFromReflecionOffset($offsetReflection);
+            $string = new MarkupContent('markdown', $info);
+
+            return new Hover($string, new Range(
+                PositionConverter::byteOffsetToPosition(
+                    ByteOffset::fromInt($symbolContext->symbol()->position()->start()),
+                    $document->__toString()
+                ),
+                PositionConverter::byteOffsetToPosition(
+                    ByteOffset::fromInt($symbolContext->symbol()->position()->end()),
+                    $document->__toString()
+                )
+            ));
+        });
+    }
+
+    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    {
+        $capabilities->hoverProvider = true;
+    }
+
+    private function infoFromReflecionOffset(ReflectionOffset $offset): string
+    {
+        $symbolContext = $offset->symbolContext();
+
+        if ($info = $this->infoFromSymbolContext($symbolContext)) {
+            return $info;
+        }
+
+        return $this->renderer->render($offset);
+    }
+
+    private function infoFromSymbolContext(SymbolContext $symbolContext): ?string
+    {
+        try {
+            return $this->renderSymbolContext($symbolContext);
+        } catch (CouldNotFormat $e) {
+        }
+
+        return null;
+    }
+
+    private function renderSymbolContext(SymbolContext $symbolContext): ?string
+    {
+        switch ($symbolContext->symbol()->symbolType()) {
+            case Symbol::METHOD:
+            case Symbol::PROPERTY:
+            case Symbol::CONSTANT:
+                return $this->renderMember($symbolContext);
+            case Symbol::CLASS_:
+                return $this->renderClass($symbolContext->type());
+            case Symbol::FUNCTION:
+                return $this->renderFunction($symbolContext);
+        }
+
+        return null;
+    }
+
+    private function renderMember(SymbolContext $symbolContext): string
+    {
+        $name = $symbolContext->symbol()->name();
+        $container = $symbolContext->containerType();
+
+        try {
+            $class = $this->reflector->reflectClassLike((string) $container);
+            $member = null;
+            $sep = '#';
+
+            // note that all class-likes (classes, traits and interfaces) have
+            // methods but not all have constants or properties, so we play safe
+            // with members() which is first-come-first-serve, rather than risk
+            // a fatal error because of a non-existing method.
+            $symbolType = $symbolContext->symbol()->symbolType();
+            switch ($symbolType) {
+                case Symbol::METHOD:
+                    $member = $class->methods()->get($name);
+                    $sep = '#';
+                    break;
+                case Symbol::CONSTANT:
+                    $sep = '::';
+                    $member = $class->members()->get($name);
+                    break;
+                case Symbol::PROPERTY:
+                    $sep = '$';
+                    $member = $class->members()->get($name);
+                    break;
+                default:
+                    return sprintf('Unknown symbol type "%s"', $symbolType);
+            }
+
+            return $this->renderer->render(new HoverInformation(
+                (string)$container.' '.$sep.' '.(string)$member->name(),
+                $this->renderer->render(
+                    new MemberDocblock($member)
+                ),
+                $member
+            ));
+        } catch (NotFound $e) {
+            return $e->getMessage();
+        }
+    }
+
+    private function renderFunction(SymbolContext $symbolContext): string
+    {
+        $name = $symbolContext->symbol()->name();
+        $function = $this->reflector->reflectFunction($name);
+
+        return $this->renderer->render(new HoverInformation($name, $function->docblock()->formatted(), $function));
+    }
+
+    private function renderClass(Type $type): string
+    {
+        try {
+            $class = $this->reflector->reflectClassLike((string) $type);
+            return $this->renderer->render(new HoverInformation((string)$type, $class->docblock()->formatted(), $class));
+        } catch (NotFound $e) {
+            return $e->getMessage();
+        }
+    }
+}

--- a/tests/LanguageServerWorseReflection/Unit/Workspace/WorkspaceIndexTest.php
+++ b/tests/LanguageServerWorseReflection/Unit/Workspace/WorkspaceIndexTest.php
@@ -7,6 +7,8 @@ use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\ReflectorBuilder;
+use function Amp\Promise\wait;
+use function Amp\delay;
 
 class WorkspaceIndexTest extends TestCase
 {
@@ -18,7 +20,7 @@ class WorkspaceIndexTest extends TestCase
     protected function setUp(): void
     {
         $reflector = ReflectorBuilder::create()->build();
-        $this->index = new WorkspaceIndex($reflector);
+        $this->index = new WorkspaceIndex($reflector, 0);
     }
 
     public function testIndexesClassesAndReturnsTextDocuments(): void

--- a/tests/LanguageServerWorseReflection/Unit/Workspace/WorkspaceIndexTest.php
+++ b/tests/LanguageServerWorseReflection/Unit/Workspace/WorkspaceIndexTest.php
@@ -7,8 +7,6 @@ use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\ReflectorBuilder;
-use function Amp\Promise\wait;
-use function Amp\delay;
 
 class WorkspaceIndexTest extends TestCase
 {


### PR DESCRIPTION
Adds a minimum time period between workspace index updates, defaulting to 100ms.

![image](https://user-images.githubusercontent.com/530801/103247689-ac843b80-495f-11eb-9e4f-ccad788dbfbd.png)

Above shows the % difference before and after for X chars in a source file (doing the operation 10x in 10 samples)

cc @BladeMF 