### PR TITLE
Allow hover template override

### DIFF
--- a/lib/LanguageServerHover/LanguageServerHoverExtension.php
+++ b/lib/LanguageServerHover/LanguageServerHoverExtension.php
@@ -17,8 +17,9 @@ use Phpactor\MapResolver\Resolver;
 
 class LanguageServerHoverExtension implements Extension
 {
+    public const PARAM_TEMPLATE_PATHS = 'language_server_hover.template_paths';
+    
     private const SERVICE_MARKDOWN_RENDERER = 'language_server_completion.object_renderer.markdown';
-    private const PARAM_TEMPLATE_PATHS = 'language_server_hover.template_paths';
 
     /**
      * {@inheritDoc}

--- a/lib/LanguageServerHover/LanguageServerHoverExtension.php
+++ b/lib/LanguageServerHover/LanguageServerHoverExtension.php
@@ -2,10 +2,13 @@
 
 namespace Phpactor\Extension\LanguageServerHover;
 
+use Phpactor\CodeBuilder\Domain\TemplatePathResolver\PhpVersionPathResolver;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\FilePathResolverExtension\FilePathResolverExtension;
 use Phpactor\ObjectRenderer\ObjectRendererBuilder;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServerHover\Handler\HoverHandler;
@@ -15,12 +18,23 @@ use Phpactor\MapResolver\Resolver;
 class LanguageServerHoverExtension implements Extension
 {
     private const SERVICE_MARKDOWN_RENDERER = 'language_server_completion.object_renderer.markdown';
+    private const PARAM_TEMPLATE_PATHS = 'language_server_hover.template_paths';
 
     /**
      * {@inheritDoc}
      */
     public function configure(Resolver $schema): void
     {
+        $schema->setDefaults([
+            self::PARAM_TEMPLATE_PATHS => [
+                '%project_config%/templates/markdown',
+                '%config%/templates/markdown',
+            ]
+        ]);
+
+        $schema->setDescriptions([
+            self::PARAM_TEMPLATE_PATHS => 'Paths in which to look for templates for hover information.'
+        ]);
     }
 
     /**
@@ -37,12 +51,27 @@ class LanguageServerHoverExtension implements Extension
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => []]);
 
         $container->register(self::SERVICE_MARKDOWN_RENDERER, function (Container $container) {
-            return ObjectRendererBuilder::create()
+            $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
+            $templatePaths = $container->getParameter(self::PARAM_TEMPLATE_PATHS);
+            $templatePaths[] = __DIR__ . '/../../templates/markdown';
+
+            $resolvedTemplatePaths = array_map(function (string $path) use ($resolver) {
+                return $resolver->resolve($path);
+            }, $templatePaths);
+
+            $phpVersion = $container->get(PhpVersionResolver::class)->resolve();
+            $paths = (new PhpVersionPathResolver($phpVersion))->resolve($resolvedTemplatePaths);
+
+            $builder = ObjectRendererBuilder::create()
                 ->setLogger($container->get(LoggingExtension::SERVICE_LOGGER))
-                ->addTemplatePath(__DIR__ . '/../../templates/markdown')
                 ->enableInterfaceCandidates()
-                ->renderEmptyOnNotFound()
-                ->build();
+                ->renderEmptyOnNotFound();
+
+            foreach ($paths as $path) {
+                $builder = $builder->addTemplatePath($path);
+            }
+            
+            return $builder->build();
         });
     }
 }

--- a/tests/LanguageServerCompletion/IntegrationTestCase.php
+++ b/tests/LanguageServerCompletion/IntegrationTestCase.php
@@ -14,6 +14,7 @@ use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\Php\PhpExtension;
 use Phpactor\Extension\ReferenceFinder\ReferenceFinderExtension;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
@@ -47,12 +48,14 @@ class IntegrationTestCase extends TestCase
             SourceCodeFilesystemExtension::class,
             LanguageServerWorseReflectionExtension::class,
             LanguageServerHoverExtension::class,
+            PhpExtension::class,
             IndexerExtension::class,
             ReferenceFinderExtension::class,
 
             LanguageServerBridgeExtension::class,
         ], [
             FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ .'/../../',
+            LanguageServerHoverExtension::PARAM_TEMPLATE_PATHS => [],
             IndexerExtension::PARAM_ENABLED_WATCHERS => [],
         ]);
         


### PR DESCRIPTION
Add a config setting `language_server_hover.template_paths` that allows the user to add more paths (other than `__DIR__ . '/../../templates/markdown'`) that are searched for twig templates for the hover content.