### PR TITLE
Generate method

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -74,6 +74,7 @@ $container = PhpactorContainer::fromExtensions([
     LoggingExtension::PARAM_ENABLED => true,
     LoggingExtension::PARAM_PATH => __DIR__ . '/../cache/phpactlor.log',
     CodeTransformExtension::PARAM_TEMPLATE_PATHS => [],
+    LanguageServerHoverExtension::PARAM_TEMPLATE_PATHS => [],
 ]);
 
 $handler = new StreamHandler(STDERR);

--- a/bin/serve
+++ b/bin/serve
@@ -73,7 +73,6 @@ $container = PhpactorContainer::fromExtensions([
     LoggingExtension::PARAM_LEVEL => 'debug',
     LoggingExtension::PARAM_ENABLED => true,
     LoggingExtension::PARAM_PATH => __DIR__ . '/../cache/phpactlor.log',
-    LanguageServerRenameWorseExtension::PARAM_FILE_RENAME_LISTENER => true,
     CodeTransformExtension::PARAM_TEMPLATE_PATHS => [],
 ]);
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "dantleech/object-renderer": "^0.1.1",
         "phpactor/phly-event-dispatcher": "^2.0.0",
         "phpactor/code-transform": "^0.4.1",
-        "phpactor/code-transform-extension": "^0.2.1",
+        "phpactor/code-transform-extension": "^0.2.2",
         "phpactor/completion": "~0.4.3",
         "phpactor/completion-extension": "^0.2.4",
         "phpactor/completion-worse-extension": "^0.2.2",

--- a/lib/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -68,7 +68,9 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
                 return CodeAction::fromArray([
                     'title' => sprintf('Fix "%s"', $diagnostic->message),
                     'kind' => self::KIND,
-                    'diagnostics' => $diagnostics,
+                    'diagnostics' => [
+                        $diagnostic
+                    ],
                     'command' => new Command(
                         'Generate method',
                         GenerateMethodCommand::NAME,

--- a/lib/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -4,11 +4,6 @@ namespace Phpactor\Extension\LanguageServerCodeTransform\CodeAction;
 
 use Amp\Promise;
 use Amp\Success;
-use Microsoft\PhpParser\Node\Expression\CallExpression;
-use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
-use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
-use Microsoft\PhpParser\Parser;
-use Microsoft\PhpParser\Token;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
@@ -21,10 +16,8 @@ use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
-use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use function Amp\call;
-use function array_filter;
 
 class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
 {
@@ -61,7 +54,7 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
      */
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range): Promise
     {
-        return call(function () use ($textDocument, $range) {
+        return call(function () use ($textDocument) {
             $diagnostics = $this->getDiagnostics($textDocument);
 
             return array_map(function (Diagnostic $diagnostic) use ($textDocument) {

--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\LanguageServerCodeTransform;
 
+use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateMethod;
 use Phpactor\CodeTransform\Domain\Refactor\ImportName;
@@ -178,10 +179,10 @@ class LanguageServerCodeTransformExtension implements Extension
 
         $container->register(GenerateMethodProvider::class, function (Container $container) {
             return new GenerateMethodProvider(
-                $container->get('worse_reflection.tolerant_parser')
+                $container->get(MissingMethodFinder::class)
             );
         }, [
-            // LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
     }

--- a/lib/LanguageServerHover/LanguageServerHoverExtension.php
+++ b/lib/LanguageServerHover/LanguageServerHoverExtension.php
@@ -28,7 +28,6 @@ class LanguageServerHoverExtension implements Extension
     {
         $schema->setDefaults([
             self::PARAM_TEMPLATE_PATHS => [
-                '%project_config%/templates/markdown',
                 '%config%/templates/markdown',
             ]
         ]);

--- a/lib/LanguageServerHover/LanguageServerHoverExtension.php
+++ b/lib/LanguageServerHover/LanguageServerHoverExtension.php
@@ -28,6 +28,7 @@ class LanguageServerHoverExtension implements Extension
     {
         $schema->setDefaults([
             self::PARAM_TEMPLATE_PATHS => [
+                '%project_config%/templates/markdown',
                 '%config%/templates/markdown',
             ]
         ]);

--- a/tests/LanguageServerCodeTransform/Unit/CodeAction/GenerateMethodProviderTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/CodeAction/GenerateMethodProviderTest.php
@@ -3,24 +3,17 @@
 namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\CodeAction;
 
 use Generator;
-use Microsoft\PhpParser\Parser;
 use PHPUnit\Framework\TestCase;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder\MissingMethod;
-use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
-use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\GenerateMethodProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\GenerateMethodCommand;
-use Phpactor\Extension\LanguageServerRename\Tests\Util\OffsetExtractor;
 use Phpactor\LanguageServerProtocol\CodeAction;
 use Phpactor\LanguageServerProtocol\Command;
 use Phpactor\LanguageServerProtocol\Diagnostic;
 use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
-use Phpactor\LanguageServerProtocol\Position;
-use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
-use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\TextDocument\TextDocument;
 use Prophecy\Argument;
@@ -75,7 +68,7 @@ class GenerateMethodProviderTest extends TestCase
             [
                 Diagnostic::fromArray([
                     'range' => ProtocolFactory::range(0, 0, 0, 5),
-                    'message' => 'Generate method "foobar"',
+                    'message' => 'Method "foobar" does not exist',
                     'severity' => DiagnosticSeverity::WARNING,
                     'source' => 'phpactor',
                 ])
@@ -83,8 +76,8 @@ class GenerateMethodProviderTest extends TestCase
         ];
     }
 
-    /** 
-     * @dataProvider provideActionsTestData 
+    /**
+     * @dataProvider provideActionsTestData
      */
     public function testProvideActions(array $missingMethods, array $expectedActions): void
     {
@@ -112,12 +105,12 @@ class GenerateMethodProviderTest extends TestCase
             ],
             [
                 CodeAction::fromArray([
-                    'title' =>  'Generate method "foobar"',
+                    'title' =>  'Fix "Method "foobar" does not exist"',
                     'kind' => GenerateMethodProvider::KIND,
                     'diagnostics' => [
                         Diagnostic::fromArray([
                             'range' => ProtocolFactory::range(0, 0, 0, 5),
-                            'message' => 'Generate method "foobar"',
+                            'message' => 'Method "foobar" does not exist',
                             'severity' => DiagnosticSeverity::WARNING,
                             'source' => 'phpactor',
                         ])

--- a/tests/LanguageServerCodeTransform/Unit/CodeAction/GenerateMethodProviderTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/CodeAction/GenerateMethodProviderTest.php
@@ -5,6 +5,8 @@ namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\CodeAction;
 use Generator;
 use Microsoft\PhpParser\Parser;
 use PHPUnit\Framework\TestCase;
+use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
+use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder\MissingMethod;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\GenerateMethodProvider;
@@ -17,201 +19,124 @@ use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
 use Phpactor\LanguageServerProtocol\Position;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\TextDocument\TextDocument;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use function Amp\Promise\wait;
 
 class GenerateMethodProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
+    const EXAMPLE_SOURCE = 'foobar';
+    const EXAMPLE_FILE = 'file:///somefile.php';
+
+    /**
+     * @var ObjectProphecy<MissingMethodFinder>
+     */
+    private $finder;
+
+    protected function setUp(): void
+    {
+        $this->finder = $this->prophesize(MissingMethodFinder::class);
+    }
+
     /**
      * @dataProvider provideDiagnosticsTestData
      */
-    public function testDiagnostics(string $text): void
+    public function testDiagnostics(array $missingMethods, array $expectedDiagnostics): void
     {
-        $result = OffsetExtractor::create()->registerRange('diagnosticsRanges', '{{', '}}')->parse($text);
-        $expectedDiagnostics = array_map(function (ByteOffsetRange $byteRange) use ($result) {
-            return new Diagnostic(
-                RangeConverter::toLspRange($byteRange, $result->source()),
-                'Generate method',
-                DiagnosticSeverity::INFORMATION,
-                null,
-                'phpactor'
-            );
-        }, $result->ranges('diagnosticsRanges'));
-
+        $this->finder->find(Argument::type(TextDocument::class))->willReturn($missingMethods);
         $provider = $this->createProvider();
 
         self::assertEquals(
             $expectedDiagnostics,
-            wait($provider->provideDiagnostics(new TextDocumentItem('file:///somefile.php', 'php', 1, $result->source())))
+            wait($provider->provideDiagnostics(
+                new TextDocumentItem(self::EXAMPLE_FILE, 'php', 1, self::EXAMPLE_SOURCE)
+            ))
         );
     }
 
     public function provideDiagnosticsTestData(): Generator
     {
-        yield 'Empty file' => [
-                '<?php '
-            ];
-        yield 'Class with no methods calls' => [
-                '<?php 
-				class Class1 
-				{
-					public function __construct() {
-					}
-
-					public function someOtherMethod() {
-						$var = 5;
-					}
-				}
-				'
-            ];
-        yield 'Class with methods calls' => [
-                '<?php 
-				class Class1 
-				{
-					public function __construct() {
-					}
-
-					public function someOtherMethod() {
-						$var = 5;
-						$this->{{methodThatIsCalled}}()->{{otherMethod}}();
-						$this->{$var}();
-                        self::{{someStaticMethod}}();
-					}
-				}
-				'
-            ];
-    }
-
-    public function testNoActionsAreProvidedWhenRangeIsNotAnInsertionPoint(): void
-    {
-        $provider = $this->createProvider();
-        self::assertEquals(
+        yield 'No missing methods' => [
             [],
-            wait($provider->provideActionsFor(new TextDocumentItem('file:///somefile.php', 'php', 1, '<?php $var = 5;'), new Range(
-                new Position(1, 7),
-                new Position(1, 9),
-            )))
-        );
-    }
-    /** @dataProvider provideActionsTestData */
-    public function testProvideActions(string $text, bool $shouldSucceed): void
-    {
-        $result = OffsetExtractor::create()
-            ->registerRange('diagnosticsRange', '{{', '}}')
-            ->registerOffset('selection', '<>')
-            ->parse($text);
+            []
+        ];
 
-        $provider = $this->createProvider();
-        $selectionPosition = PositionConverter::byteOffsetToPosition($result->offset('selection'), $result->source());
-        $uri = 'file:///somefile.php';
-
-        if ($shouldSucceed) {
-            $expectedDiagnostic = new Diagnostic(
-                RangeConverter::toLspRange($result->range('diagnosticsRange'), $result->source()),
-                'Generate method',
-                DiagnosticSeverity::INFORMATION,
-                null,
-                'phpactor'
-            );
-            $codeActions = [
-                CodeAction::fromArray([
-                    'title' =>  'Generate method (if not exists)',
-                    'kind' => GenerateMethodProvider::KIND,
-                    'diagnostics' => [ $expectedDiagnostic ],
-                    'command' => new Command(
-                        'Generate method',
-                        GenerateMethodCommand::NAME,
-                        [
-                            $uri,
-                            $result->offset('selection')->toInt()
-                        ]
-                    )
+        yield 'Missing method' => [
+            [
+                new MissingMethod(self::EXAMPLE_SOURCE, ByteOffsetRange::fromInts(0, 5))
+            ],
+            [
+                Diagnostic::fromArray([
+                    'range' => ProtocolFactory::range(0, 0, 0, 5),
+                    'message' => 'Generate method "foobar"',
+                    'severity' => DiagnosticSeverity::WARNING,
+                    'source' => 'phpactor',
                 ])
-            ];
-        } else {
-            $codeActions = [];
-        }
+            ]
+        ];
+    }
 
+    /** 
+     * @dataProvider provideActionsTestData 
+     */
+    public function testProvideActions(array $missingMethods, array $expectedActions): void
+    {
+        $this->finder->find(Argument::type(TextDocument::class))->willReturn($missingMethods);
+        $provider = $this->createProvider();
         self::assertEquals(
-            $codeActions,
-            wait($provider->provideActionsFor(new TextDocumentItem($uri, 'php', 1, $result->source()), new Range(
-                $selectionPosition,
-                $selectionPosition,
-            )))
+            $expectedActions,
+            wait($provider->provideActionsFor(
+                new TextDocumentItem(self::EXAMPLE_FILE, 'php', 1, self::EXAMPLE_SOURCE),
+                ProtocolFactory::range(0, 0, 0, 0)
+            ))
         );
     }
 
     public function provideActionsTestData(): Generator
     {
-        yield
-            'Empty file' => [
-                '<?php <>',
-                false
-            ];
-
-        yield 'Outside methods calls' => [
-            '<?php 
-class Class1 
-{
-    public function __construct() {
-    }
-
-    public function someOtherMethod() {
-        $v<>ar = 5;
-        $this->methodThatIsCalled();
-    }
-    }
-',
-                            false
+        yield 'No missing methods' => [
+            [],
+            []
         ];
-        yield 'Instance method call' => [
-                '<?php 
-class Class1 
-{
-    public function __construct() {
+
+        yield 'Missing method' => [
+            [
+                new MissingMethod(self::EXAMPLE_SOURCE, ByteOffsetRange::fromInts(0, 5))
+            ],
+            [
+                CodeAction::fromArray([
+                    'title' =>  'Generate method "foobar"',
+                    'kind' => GenerateMethodProvider::KIND,
+                    'diagnostics' => [
+                        Diagnostic::fromArray([
+                            'range' => ProtocolFactory::range(0, 0, 0, 5),
+                            'message' => 'Generate method "foobar"',
+                            'severity' => DiagnosticSeverity::WARNING,
+                            'source' => 'phpactor',
+                        ])
+                    ],
+                    'command' => new Command(
+                        'Generate method',
+                        GenerateMethodCommand::NAME,
+                        [
+                            self::EXAMPLE_FILE,
+                            0
+                        ]
+                    )
+                ])
+            ]
+        ];
     }
 
-    public function someOtherMethod() {
-        $var = 5;
-        $this->{{methodTh<>atIsCalled}}();
-    }
-    }
-',
-                            true
-            ];
-        yield 'Static method call' => [
-                '<?php 
-class Class1 
-{
-    public function __construct() {
-    }
-
-    public function someOtherMethod() {
-        $var = 5;
-        self::{{methodTh<>atIsCalled}}();
-    }
-    }
-',
-                            true
-            ];
-        yield 'Dynamic method name call' => [
-                '<?php 
-class Class1 
-{
-    public function __construct() {
-    }
-
-    public function someOtherMethod() {
-        $var = 5;
-        self::{$v<>ar}();
-    }
-    }
-',
-                            false
-            ];
-    }
     private function createProvider(): GenerateMethodProvider
     {
-        return new GenerateMethodProvider(new Parser());
+        return new GenerateMethodProvider($this->finder->reveal());
     }
 }


### PR DESCRIPTION
This PR updates the method generator to use the ne `MissingMethodFinder` and act on the entire document:

- Invoking the code action anywhere offers the possiblity to geneate missing methods
- Diagnostics are enabled.

@BladeMF note that as we no longer use the parser, the tests have been simplified, the deleted test cases could be moved to code-transform however.

I also notice that, at least for me, generating methods in a foreign class does not place the method in the correct place (probably the source or offset is being wrongly mapped).