### PR TITLE
Import all names

### DIFF
--- a/lib/As1/asd.php
+++ b/lib/As1/asd.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Phpactor\Extension\As1;
-
-class asd
-{
-}

--- a/lib/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
@@ -148,13 +148,13 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
     {
         return CodeAction::fromArray([
             'title' => sprintf(
-                'Import all unresolved classes',
+                'Import all unresolved names',
             ),
-            'kind' => 'quickfix.import_all_unresolved_classes',
+            'kind' => 'quickfix.import_all_unresolved_names',
             'isPreferred' => true,
             'diagnostics' => [],
             'command' => new Command(
-                'Import all unresolved classes',
+                'Import all unresolved names',
                 ImportAllUnresolvedNamesCommand::NAME,
                 [
                     $item->uri,

--- a/lib/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
@@ -3,17 +3,11 @@
 namespace Phpactor\Extension\LanguageServerCodeTransform\CodeAction;
 
 use Amp\Promise;
-use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
 use Phpactor\CodeTransform\Domain\NameWithByteOffset;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportAllUnresolvedNamesCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportNameCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\CandidateFinder;
-use Phpactor\Indexer\Model\Query\Criteria;
-use Phpactor\Indexer\Model\Record;
-use Phpactor\Indexer\Model\Record\ConstantRecord;
-use Phpactor\Indexer\Model\Record\HasFullyQualifiedName;
-use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\LanguageServerProtocol\CodeAction;
 use Phpactor\LanguageServerProtocol\Command;
 use Phpactor\LanguageServerProtocol\Diagnostic;
@@ -22,9 +16,6 @@ use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
-use Phpactor\TextDocument\TextDocumentBuilder;
-use Phpactor\WorseReflection\Core\Exception\NotFound;
-use Phpactor\WorseReflection\Core\Reflector\FunctionReflector;
 use function Amp\call;
 use function Amp\delay;
 
@@ -112,10 +103,6 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
                     'phpactor'
                 )
             ];
-        }
-
-        if (count($candidates) === 0) {
-            return [];
         }
 
         return [

--- a/lib/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
@@ -44,7 +44,7 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
     {
         return call(function () use ($item) {
             $actions = [];
-            foreach ($this->finder->find($item) as $candidate) {
+            foreach ($this->finder->importCandidates($item) as $candidate) {
                 $actions[] = $this->codeActionForFqn($candidate->unresolvedName(), $candidate->candidateFqn(), $item);
                 yield delay(1);
             }
@@ -91,7 +91,7 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
             )
         );
 
-        $candidates = iterator_to_array($this->finder->find($item));
+        $candidates = iterator_to_array($this->finder->importCandidates($item));
 
         if (count($candidates) === 0) {
             return [

--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -29,7 +29,6 @@ use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\Indexer\Model\SearchClient;
-use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\TextDocument\TextDocumentLocator;

--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -21,6 +21,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\TransformerCodeAct
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\CreateClassCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExtractMethodCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\GenerateMethodCommand;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportAllUnresolvedNamesCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportNameCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\TransformCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\CandidateFinder;
@@ -28,6 +29,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\Indexer\Model\SearchClient;
+use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\TextDocument\TextDocumentLocator;
@@ -123,6 +125,19 @@ class LanguageServerCodeTransformExtension implements Extension
         }, [
             LanguageServerExtension::TAG_COMMAND => [
                 'name' => ExtractMethodCommand::NAME
+            ],
+        ]);
+
+        $container->register(ImportAllUnresolvedNamesCommand::class, function (Container $container) {
+            return new ImportAllUnresolvedNamesCommand(
+                $container->get(CandidateFinder::class),
+                $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
+                $container->get(ImportNameCommand::class),
+                $container->get(ClientApi::class)
+            );
+        }, [
+            LanguageServerExtension::TAG_COMMAND => [
+                'name' => ImportAllUnresolvedNamesCommand::NAME
             ],
         ]);
     }

--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -23,7 +23,8 @@ use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExtractMethodComma
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\GenerateMethodCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportNameCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\TransformCommand;
-use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImporter;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\CandidateFinder;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\Indexer\Model\SearchClient;
@@ -128,12 +129,17 @@ class LanguageServerCodeTransformExtension implements Extension
 
     private function registerCodeActions(ContainerBuilder $container): void
     {
-        $container->register(ImportNameProvider::class, function (Container $container) {
-            return new ImportNameProvider(
+        $container->register(CandidateFinder::class, function (Container $container) {
+            return new CandidateFinder(
                 $container->get(UnresolvableClassNameFinder::class),
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
                 $container->get(SearchClient::class),
                 $container->getParameter(self::PARAM_IMPORT_GLOBALS)
+            );
+        });
+        $container->register(ImportNameProvider::class, function (Container $container) {
+            return new ImportNameProvider(
+                $container->get(CandidateFinder::class)
             );
         }, [
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => [],

--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -23,6 +23,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExtractMethodComma
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\GenerateMethodCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportNameCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\TransformCommand;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImporter;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\Indexer\Model\SearchClient;
@@ -58,9 +59,12 @@ class LanguageServerCodeTransformExtension implements Extension
 
     private function registerCommands(ContainerBuilder $container): void
     {
+        $container->register(NameImporter::class, function (Container $container) {
+            return new NameImporter($container->get(ImportName::class));
+        });
         $container->register(ImportNameCommand::class, function (Container $container) {
             return new ImportNameCommand(
-                $container->get(ImportName::class),
+                $container->get(NameImporter::class),
                 $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
                 $container->get(TextEditConverter::class),
                 $container->get(ClientApi::class)

--- a/lib/LanguageServerCodeTransform/LspCommand/ImportAllUnresolvedNamesCommand.php
+++ b/lib/LanguageServerCodeTransform/LspCommand/ImportAllUnresolvedNamesCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\LspCommand;
+
+use Phpactor\Indexer\Model\SearchClient;
+use Phpactor\WorseReflection\Core\Reflector\FunctionReflector;
+use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
+
+class ImportAllUnresolvedNamesCommand
+{
+    /**
+     * @var UnresolvableClassNameFinder
+     */
+    private $finder;
+
+    /**
+     * @var FunctionReflector
+     */
+    private $functionReflector;
+
+    /**
+     * @var SearchClient
+     */
+    private $client;
+
+    /**
+     * @var bool
+     */
+    private $importGlobals;
+
+    public function __construct(
+        UnresolvableClassNameFinder $finder,
+        FunctionReflector $functionReflector,
+        SearchClient $client,
+        bool $importGlobals = false
+    ) {
+        $this->finder = $finder;
+        $this->functionReflector = $functionReflector;
+        $this->client = $client;
+        $this->importGlobals = $importGlobals;
+    }
+
+    public function __invoke(
+        string $uri
+    )
+    {
+    }
+}

--- a/lib/LanguageServerCodeTransform/LspCommand/ImportAllUnresolvedNamesCommand.php
+++ b/lib/LanguageServerCodeTransform/LspCommand/ImportAllUnresolvedNamesCommand.php
@@ -6,15 +6,10 @@ use Amp\Promise;
 use Phpactor\CodeTransform\Domain\NameWithByteOffset;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\CandidateFinder;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameCandidate;
-use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\LanguageServerProtocol\MessageActionItem;
-use Phpactor\LanguageServerProtocol\ShowMessageRequestParams;
 use Phpactor\LanguageServer\Core\Command\Command;
-use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Workspace\Workspace;
-use Phpactor\WorseReflection\Core\Reflector\FunctionReflector;
-use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
 use function Amp\call;
 
 class ImportAllUnresolvedNamesCommand implements Command
@@ -53,10 +48,12 @@ class ImportAllUnresolvedNamesCommand implements Command
         $this->importName = $importName;
     }
 
+    /**
+     * @return Promise<void>
+     */
     public function __invoke(
         string $uri
-    ): Promise
-    {
+    ): Promise {
         return call(function () use ($uri) {
             $item = $this->workspace->get($uri);
             foreach ($this->candidateFinder->unresolved($item) as $unresolvedName) {
@@ -99,7 +96,8 @@ class ImportAllUnresolvedNamesCommand implements Command
             }
 
             $choice = yield $this->client->window()->showMessageRequest()->info(sprintf(
-                'Ambiguous class "%s":', $unresolved->name()->__toString()
+                'Ambiguous class "%s":',
+                $unresolved->name()->__toString()
             ), ...array_map(function (NameCandidate $candidate) {
                 return new MessageActionItem($candidate->candidateFqn());
             }, $candidates));

--- a/lib/LanguageServerCodeTransform/LspCommand/ImportAllUnresolvedNamesCommand.php
+++ b/lib/LanguageServerCodeTransform/LspCommand/ImportAllUnresolvedNamesCommand.php
@@ -32,25 +32,25 @@ class ImportAllUnresolvedNamesCommand implements Command
     private $workspace;
 
     /**
-     * @var CommandDispatcher
-     */
-    private $dispatcher;
-
-    /**
      * @var ClientApi
      */
     private $client;
 
+    /**
+     * @var ImportNameCommand
+     */
+    private $importName;
+
     public function __construct(
         CandidateFinder $candidateFinder,
         Workspace $workspace,
-        CommandDispatcher $dispatcher,
+        ImportNameCommand $importName,
         ClientApi $client
     ) {
         $this->candidateFinder = $candidateFinder;
         $this->workspace = $workspace;
-        $this->dispatcher = $dispatcher;
         $this->client = $client;
+        $this->importName = $importName;
     }
 
     public function __invoke(
@@ -71,12 +71,12 @@ class ImportAllUnresolvedNamesCommand implements Command
                     continue;
                 }
 
-                $this->dispatcher->dispatch(ImportNameCommand::NAME, [
+                yield $this->importName->__invoke(
                     $uri,
-                    $unresolvedName->byteOffset(),
+                    $unresolvedName->byteOffset()->toInt(),
                     $unresolvedName->type(),
                     $candidate->candidateFqn()
-                ]);
+                );
             }
         });
     }

--- a/lib/LanguageServerCodeTransform/LspCommand/ImportNameCommand.php
+++ b/lib/LanguageServerCodeTransform/LspCommand/ImportNameCommand.php
@@ -7,18 +7,11 @@ use Amp\Success;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
 use Phpactor\LanguageServerProtocol\WorkspaceEdit;
 use Phpactor\CodeTransform\Domain\Exception\TransformException;
-use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;
-use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyImportedException;
-use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport;
 use Phpactor\CodeTransform\Domain\Refactor\ImportName;
-use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
 use Phpactor\LanguageServer\Core\Command\Command;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Workspace\Workspace;
-use Phpactor\Name\FullyQualifiedName;
-use Phpactor\TextDocument\ByteOffset;
-use Phpactor\TextDocument\TextDocumentUri;
 
 class ImportNameCommand implements Command
 {

--- a/lib/LanguageServerCodeTransform/LspCommand/ImportNameCommand.php
+++ b/lib/LanguageServerCodeTransform/LspCommand/ImportNameCommand.php
@@ -4,7 +4,7 @@ namespace Phpactor\Extension\LanguageServerCodeTransform\LspCommand;
 
 use Amp\Promise;
 use Amp\Success;
-use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImporter;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
 use Phpactor\LanguageServerProtocol\WorkspaceEdit;
 use Phpactor\CodeTransform\Domain\Exception\TransformException;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;

--- a/lib/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -16,7 +16,7 @@ use Phpactor\WorseReflection\Core\Reflector\FunctionReflector;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use function Amp\call;
 
-final class CandidateFinder
+class CandidateFinder
 {
     /**
      * @var UnresolvableClassNameFinder

--- a/lib/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport;
+
+use Generator;
+use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
+use Phpactor\CodeTransform\Domain\NameWithByteOffsets;
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\Record\ConstantRecord;
+use Phpactor\Indexer\Model\Record\HasFullyQualifiedName;
+use Phpactor\Indexer\Model\SearchClient;
+use Phpactor\CodeTransform\Domain\NameWithByteOffset;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Core\Reflector\FunctionReflector;
+use Phpactor\WorseReflection\Core\Exception\NotFound;
+use function Amp\call;
+
+final class CandidateFinder
+{
+    /**
+     * @var UnresolvableClassNameFinder
+     */
+    private $finder;
+
+    /**
+     * @var SearchClient
+     */
+    private $client;
+
+    /**
+     * @var bool
+     */
+    private $importGlobals;
+
+    /**
+     * @var FunctionReflector
+     */
+    private $functionReflector;
+
+    public function __construct(UnresolvableClassNameFinder $finder, FunctionReflector $functionReflector, SearchClient $client, bool $importGlobals = false)
+    {
+        $this->finder = $finder;
+        $this->client = $client;
+        $this->importGlobals = $importGlobals;
+        $this->functionReflector = $functionReflector;
+    }
+
+    public function unresolved(TextDocumentItem $item): NameWithByteOffsets
+    {
+        $names = $this->finder->find(
+            TextDocumentBuilder::create($item->text)->uri($item->uri)->language('php')->build()
+        );
+        return new NameWithByteOffsets(...array_filter(iterator_to_array($names), function (NameWithByteOffset $unresolvedName) {
+            if ($this->isUnresolvedGlobalFunction($unresolvedName)) {
+                if (false === $this->importGlobals) {
+                    return false;
+                }
+            }
+            return true;
+        }));
+    }
+
+    /**
+     * @return Generator<NameCandidate>
+     */
+    public function find(
+        TextDocumentItem $item
+    ): Generator
+    {
+        $actions = [];
+        foreach ($this->unresolved($item) as $unresolvedName) {
+            if ($this->isUnresolvedGlobalFunction($unresolvedName)) {
+                if (false === $this->importGlobals) {
+                    continue;
+                }
+                yield new NameCandidate($unresolvedName, $unresolvedName->name()->head()->__toString());
+                continue;
+            }
+            assert($unresolvedName instanceof NameWithByteOffset);
+
+            $candidates = $this->findCandidates($unresolvedName);
+
+            foreach ($candidates as $candidate) {
+                assert($candidate instanceof HasFullyQualifiedName);
+
+                // skip constants for now
+                if ($candidate instanceof ConstantRecord) {
+                    continue;
+                }
+
+                $fqn = $candidate->fqn()->__toString();
+                yield new NameCandidate($unresolvedName, $candidate->fqn());
+            }
+        }
+
+        return $actions;
+    }
+
+    private function isUnresolvedGlobalFunction(NameWithByteOffset $unresolvedName): bool
+    {
+        if ($unresolvedName->type() !== NameWithByteOffset::TYPE_FUNCTION) {
+            return false;
+        }
+
+        try {
+            $s = $this->functionReflector->sourceCodeForFunction(
+                $unresolvedName->name()->head()->__toString()
+            );
+            return true;
+        } catch (NotFound $notFound) {
+        }
+
+        return false;
+    }
+
+    private function findCandidates(NameWithByteOffset $unresolvedName): array
+    {
+        $candidates = [];
+        foreach ($this->client->search(Criteria::and(
+            Criteria::or(
+                Criteria::isConstant(),
+                Criteria::isClass(),
+                Criteria::isFunction()
+            ),
+            Criteria::exactShortName($unresolvedName->name()->head()->__toString())
+        )) as $candidate) {
+            $candidates[] = $candidate;
+        }
+
+        return $candidates;
+    }
+}

--- a/lib/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -14,7 +14,6 @@ use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Reflector\FunctionReflector;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
-use function Amp\call;
 
 class CandidateFinder
 {
@@ -66,8 +65,7 @@ class CandidateFinder
      */
     public function importCandidates(
         TextDocumentItem $item
-    ): Generator
-    {
+    ): Generator {
         $actions = [];
         foreach ($this->unresolved($item) as $unresolvedName) {
             yield from $this->candidatesForUnresolvedName($unresolvedName);

--- a/lib/LanguageServerCodeTransform/Model/NameImport/NameCandidate.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/NameCandidate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport;
+
+use Phpactor\CodeTransform\Domain\NameWithByteOffset;
+
+class NameCandidate
+{
+    /**
+     * @var NameWithByteOffset
+     */
+    private $unresolvedName;
+    /**
+     * @var string
+     */
+    private $candidateFqn;
+
+    public function __construct(NameWithByteOffset $name, string $candidateFqn)
+    {
+        $this->unresolvedName = $name;
+        $this->candidateFqn = $candidateFqn;
+    }
+
+    public function candidateFqn(): string
+    {
+        return $this->candidateFqn;
+    }
+
+    public function unresolvedName(): NameWithByteOffset
+    {
+        return $this->unresolvedName;
+    }
+}

--- a/lib/LanguageServerCodeTransform/Model/NameImport/NameImporter.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/NameImporter.php
@@ -2,21 +2,13 @@
 
 namespace Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport;
 
-use Amp\Promise;
-use Amp\Success;
-use Phpactor\LanguageServerProtocol\TextDocument;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
-use Phpactor\LanguageServerProtocol\WorkspaceEdit;
-use Phpactor\CodeTransform\Domain\Exception\TransformException;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyImportedException;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport;
 use Phpactor\CodeTransform\Domain\Refactor\ImportName;
 use Phpactor\CodeTransform\Domain\SourceCode;
-use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
 use Phpactor\LanguageServer\Core\Command\Command;
-use Phpactor\LanguageServer\Core\Server\ClientApi;
-use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\Name\FullyQualifiedName;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocumentUri;
@@ -76,4 +68,3 @@ class NameImporter implements Command
         }
     }
 }
-

--- a/lib/LanguageServerCodeTransform/Model/NameImport/NameImporter.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/NameImporter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phpactor\Extension\LanguageServerCodeTransform\Model;
+namespace Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport;
 
 use Amp\Promise;
 use Amp\Success;

--- a/lib/LanguageServerCodeTransform/Model/NameImporter.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImporter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Model;
+
+use Amp\Promise;
+use Amp\Success;
+use Phpactor\LanguageServerProtocol\TextDocument;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServerProtocol\WorkspaceEdit;
+use Phpactor\CodeTransform\Domain\Exception\TransformException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyImportedException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport;
+use Phpactor\CodeTransform\Domain\Refactor\ImportName;
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
+use Phpactor\LanguageServer\Core\Command\Command;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Core\Workspace\Workspace;
+use Phpactor\Name\FullyQualifiedName;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocumentUri;
+use Phpactor\TextDocument\TextEdits;
+
+class NameImporter implements Command
+{
+    /**
+     * @var ImportName
+     */
+    private $importName;
+
+
+    public function __construct(
+        ImportName $importName
+    ) {
+        $this->importName = $importName;
+    }
+
+    public function __invoke(
+        TextDocumentItem $document,
+        int $offset,
+        string $type,
+        string $fqn,
+        ?string $alias = null
+    ): ?TextEdits {
+        $sourceCode = SourceCode::fromStringAndPath(
+            $document->text,
+            TextDocumentUri::fromString($document->uri)->path()
+        );
+
+        $nameImport = $type === 'function' ?
+            NameImport::forFunction($fqn, $alias) :
+            NameImport::forClass($fqn, $alias);
+
+        try {
+            return $this->importName->importName(
+                $sourceCode,
+                ByteOffset::fromInt($offset),
+                $nameImport
+            );
+        } catch (NameAlreadyImportedException $error) {
+            if ($error->existingName() === $fqn) {
+                return null;
+            }
+
+            $name = FullyQualifiedName::fromString($fqn);
+            $prefix = 'Aliased';
+            if (isset($name->toArray()[0])) {
+                $prefix = $name->toArray()[0];
+            }
+
+            return $this->__invoke($document, $offset, $type, $fqn, $prefix . $error->name());
+        } catch (AliasAlreadyUsedException $error) {
+            $prefix = 'Aliased';
+            return $this->__invoke($document, $offset, $type, $fqn, $prefix . $error->name());
+        }
+    }
+}
+

--- a/lib/test2.php
+++ b/lib/test2.php
@@ -1,9 +1,0 @@
-<?php
-
-use PhpBench\Tests\Unit\Benchmark\Metadata\classes\Test;
-use Phpactor\ClassMover\FoundReferences;
-use http\Client\Request;
-
-new Request;
-new Test;
-new FoundReferences;

--- a/lib/test2.php
+++ b/lib/test2.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Phpactor\Extension;
+use PhpBench\Tests\Unit\Benchmark\Metadata\classes\Test;
+use Phpactor\ClassMover\FoundReferences;
+use http\Client\Request;
 
-class test2
-{
-}
+new Request;
+new Test;
+new FoundReferences;

--- a/tests/LanguageServerCodeTransform/IntegrationTestCase.php
+++ b/tests/LanguageServerCodeTransform/IntegrationTestCase.php
@@ -50,6 +50,7 @@ class IntegrationTestCase extends TestCase
             CodeTransformExtension::PARAM_TEMPLATE_PATHS => [],
             FilePathResolverExtension::PARAM_PROJECT_ROOT => $this->workspace()->path(),
             IndexerExtension::PARAM_INDEX_PATH => $this->workspace()->path('index'),
+            LoggingExtension::PARAM_ENABLED => true,
             IndexerExtension::PARAM_ENABLED_WATCHERS => [],
             LanguageServerExtension::PARAM_DIAGNOSTIC_SLEEP_TIME => 0,
         ], $config));

--- a/tests/LanguageServerCodeTransform/Unit/CodeAction/ImportNameProviderTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/CodeAction/ImportNameProviderTest.php
@@ -170,7 +170,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 $bar = [];
                 explode(array_keys($bar));
                 EOT
-        , 2, 2, true
+        , 3, 2, true
         ];
 
         yield 'constant' => [

--- a/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\LspCommand;
 
-use Amp\Promise;
 use Amp\Success;
 use PHPUnit\Framework\TestCase;
 use Phpactor\CodeTransform\Domain\NameWithByteOffset;
@@ -14,9 +13,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameCandidat
 use Phpactor\LanguageServerProtocol\MessageActionItem;
 use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
 use Phpactor\LanguageServer\LanguageServerTesterBuilder;
-use Phpactor\LanguageServer\Test\LanguageServerTester;
 use Phpactor\Name\FullyQualifiedName;
-use Phpactor\Name\Name;
 use Phpactor\TextDocument\ByteOffset;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -24,9 +21,9 @@ use function Amp\Promise\wait;
 
 class ImportAllUnresolvedNamesCommandTest extends TestCase
 {
+    use ProphecyTrait;
     const EXAMPLE_URI = 'file:///foobar';
     const EXAMPLE_CANDIDATE = 'Foobar';
-    use ProphecyTrait;
 
     /**
      * @var CandidateFinder
@@ -137,7 +134,6 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
             )
         );
         return $builder;
-
     }
 
     private function createUnresolvedName(): NameWithByteOffset

--- a/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
@@ -36,12 +36,12 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
     /**
      * @var CommandDispatcher
      */
-    private $commandDispatcher;
+    private $importName;
 
     public function setUp(): void
     {
         $this->candidateFinder = $this->prophesize(CandidateFinder::class);
-        $this->commandDispatcher = $this->prophesize(CommandDispatcher::class);
+        $this->importName = $this->prophesize(ImportNameCommand::class);
     }
 
     public function testNoUnresolvedNamesDoesNothing(): void
@@ -91,7 +91,7 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
         $this->candidateFinder->candidatesForUnresolvedName($unresolvedName)->willYield([
             new NameCandidate($unresolvedName, self::EXAMPLE_CANDIDATE)
         ]);
-        $this->commandDispatcher->dispatch(ImportNameCommand::NAME, Argument::any())->willReturn(new Success(true))->shouldBeCalled();
+        $this->importName->__invoke(Argument::cetera())->willReturn(new Success(true))->shouldBeCalled();
 
         wait($server->workspace()->executeCommand(ImportAllUnresolvedNamesCommand::NAME, [
             self::EXAMPLE_URI
@@ -112,7 +112,7 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
             new NameCandidate($unresolvedName, self::EXAMPLE_CANDIDATE),
             new NameCandidate($unresolvedName, 'Barfoo')
         ]);
-        $this->commandDispatcher->dispatch(ImportNameCommand::NAME, Argument::any())->willReturn(new Success(true))->shouldBeCalled();
+        $this->importName->__invoke(Argument::cetera())->willReturn(new Success(true))->shouldBeCalled();
 
         $promise = $server->workspace()->executeCommand(ImportAllUnresolvedNamesCommand::NAME, [
             self::EXAMPLE_URI
@@ -132,7 +132,7 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
             new ImportAllUnresolvedNamesCommand(
                 $this->candidateFinder->reveal(),
                 $builder->workspace(),
-                $this->commandDispatcher->reveal(),
+                $this->importName->reveal(),
                 $builder->clientApi()
             )
         );

--- a/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\LspCommand;
+
+use Amp\Promise;
+use Amp\Success;
+use PHPUnit\Framework\TestCase;
+use Phpactor\CodeTransform\Domain\NameWithByteOffset;
+use Phpactor\CodeTransform\Domain\NameWithByteOffsets;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportAllUnresolvedNamesCommand;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportNameCommand;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\CandidateFinder;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameCandidate;
+use Phpactor\LanguageServerProtocol\MessageActionItem;
+use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
+use Phpactor\LanguageServer\LanguageServerTesterBuilder;
+use Phpactor\LanguageServer\Test\LanguageServerTester;
+use Phpactor\Name\FullyQualifiedName;
+use Phpactor\Name\Name;
+use Phpactor\TextDocument\ByteOffset;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use function Amp\Promise\wait;
+
+class ImportAllUnresolvedNamesCommandTest extends TestCase
+{
+    const EXAMPLE_URI = 'file:///foobar';
+    const EXAMPLE_CANDIDATE = 'Foobar';
+    use ProphecyTrait;
+
+    /**
+     * @var CandidateFinder
+     */
+    private $candidateFinder;
+
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    public function setUp(): void
+    {
+        $this->candidateFinder = $this->prophesize(CandidateFinder::class);
+        $this->commandDispatcher = $this->prophesize(CommandDispatcher::class);
+    }
+
+    public function testNoUnresolvedNamesDoesNothing(): void
+    {
+        $builder = $this->createBuilder();
+        $server = $builder->build();
+        $server->textDocument()->open(self::EXAMPLE_URI, 'foobar');
+
+        $this->candidateFinder->unresolved($builder->workspace()->get(self::EXAMPLE_URI))->willReturn(new NameWithByteOffsets());
+
+        wait($server->workspace()->executeCommand(ImportAllUnresolvedNamesCommand::NAME, [
+            self::EXAMPLE_URI
+        ]));
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNoCandidates(): void
+    {
+        $builder = $this->createBuilder();
+        $server = $builder->build();
+        $server->textDocument()->open(self::EXAMPLE_URI, 'foobar');
+
+        $unresolvedName = $this->createUnresolvedName();
+        $this->candidateFinder->unresolved($builder->workspace()->get(self::EXAMPLE_URI))->willReturn(new NameWithByteOffsets(
+            $unresolvedName
+        ));
+        $this->candidateFinder->candidatesForUnresolvedName($unresolvedName)->willYield([]);
+
+        wait($server->workspace()->executeCommand(ImportAllUnresolvedNamesCommand::NAME, [
+            self::EXAMPLE_URI
+        ]));
+
+        $notification = $server->transmitter()->shiftNotification();
+        self::assertEquals('Class "Foobar" has no candidates', $notification->params['message']);
+    }
+
+    public function testOneCandidate(): void
+    {
+        $builder = $this->createBuilder();
+        $server = $builder->build();
+        $server->textDocument()->open(self::EXAMPLE_URI, 'foobar');
+
+        $unresolvedName = $this->createUnresolvedName();
+        $this->candidateFinder->unresolved($builder->workspace()->get(self::EXAMPLE_URI))->willReturn(new NameWithByteOffsets(
+            $unresolvedName
+        ));
+        $this->candidateFinder->candidatesForUnresolvedName($unresolvedName)->willYield([
+            new NameCandidate($unresolvedName, self::EXAMPLE_CANDIDATE)
+        ]);
+        $this->commandDispatcher->dispatch(ImportNameCommand::NAME, Argument::any())->willReturn(new Success(true))->shouldBeCalled();
+
+        wait($server->workspace()->executeCommand(ImportAllUnresolvedNamesCommand::NAME, [
+            self::EXAMPLE_URI
+        ]));
+    }
+
+    public function testAsksUserToSelectFromMultipleCandidates(): void
+    {
+        $builder = $this->createBuilder();
+        $server = $builder->build();
+        $server->textDocument()->open(self::EXAMPLE_URI, 'foobar');
+
+        $unresolvedName = $this->createUnresolvedName();
+        $this->candidateFinder->unresolved($builder->workspace()->get(self::EXAMPLE_URI))->willReturn(new NameWithByteOffsets(
+            $unresolvedName
+        ));
+        $this->candidateFinder->candidatesForUnresolvedName($unresolvedName)->willYield([
+            new NameCandidate($unresolvedName, self::EXAMPLE_CANDIDATE),
+            new NameCandidate($unresolvedName, 'Barfoo')
+        ]);
+        $this->commandDispatcher->dispatch(ImportNameCommand::NAME, Argument::any())->willReturn(new Success(true))->shouldBeCalled();
+
+        $promise = $server->workspace()->executeCommand(ImportAllUnresolvedNamesCommand::NAME, [
+            self::EXAMPLE_URI
+        ]);
+        $builder->responseWatcher()->resolveLastResponse(new MessageActionItem(self::EXAMPLE_CANDIDATE));
+        wait($promise);
+    }
+
+    private function createBuilder(): LanguageServerTesterBuilder
+    {
+        $builder = LanguageServerTesterBuilder::createBare()
+            ->enableCommands()
+            ->enableTextDocuments();
+        
+        $builder->addCommand(
+            ImportAllUnresolvedNamesCommand::NAME,
+            new ImportAllUnresolvedNamesCommand(
+                $this->candidateFinder->reveal(),
+                $builder->workspace(),
+                $this->commandDispatcher->reveal(),
+                $builder->clientApi()
+            )
+        );
+        return $builder;
+
+    }
+
+    private function createUnresolvedName(): NameWithByteOffset
+    {
+        return new NameWithByteOffset(FullyQualifiedName::fromString(self::EXAMPLE_CANDIDATE), ByteOffset::fromInt(10), NameWithByteOffset::TYPE_CLASS);
+    }
+}

--- a/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportNameCommandTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportNameCommandTest.php
@@ -4,6 +4,7 @@ namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\LspCommand;
 
 use Amp\Promise;
 use Phpactor\Extension\LanguageServerBridge\TextDocument\WorkspaceTextDocumentLocator;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImporter;
 use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResponse;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\CodeTransform\Domain\Exception\TransformException;
@@ -63,7 +64,7 @@ class ImportNameCommandTest extends TestCase
         $this->rpcClient = TestRpcClient::create();
         $this->converter = new TextEditConverter(new LocationConverter(new WorkspaceTextDocumentLocator($this->workspace)));
         $this->command = new ImportNameCommand(
-            $this->importName->reveal(),
+            new NameImporter($this->importName->reveal()),
             $this->workspace,
             $this->converter,
             new ClientApi($this->rpcClient)

--- a/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportNameCommandTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportNameCommandTest.php
@@ -4,7 +4,7 @@ namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\LspCommand;
 
 use Amp\Promise;
 use Phpactor\Extension\LanguageServerBridge\TextDocument\WorkspaceTextDocumentLocator;
-use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImporter;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
 use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResponse;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\CodeTransform\Domain\Exception\TransformException;


### PR DESCRIPTION
Additional code action from `ImportName`  provider to trigger new Command `ImportAllUnresolvedNames`.

- Will automatically add all unresolved names with exactly 1 candidate
- Will prompt user to resolve ambiguous imports

![image](https://user-images.githubusercontent.com/530801/119276695-6df36400-bc13-11eb-8406-52586f1165ad.png)

