### PR TITLE
Introduce NameImporterResult

### DIFF
--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -12,7 +12,6 @@ use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\CodeTransform\CodeTransformExtension;
-use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\CreateClassProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractMethodProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\GenerateMethodProvider;
@@ -68,7 +67,6 @@ class LanguageServerCodeTransformExtension implements Extension
             return new ImportNameCommand(
                 $container->get(NameImporter::class),
                 $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
-                $container->get(TextEditConverter::class),
                 $container->get(ClientApi::class)
             );
         }, [

--- a/lib/LanguageServerCodeTransform/Model/NameImport/NameImporterResult.php
+++ b/lib/LanguageServerCodeTransform/Model/NameImport/NameImporterResult.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport;
+
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport;
+use Phpactor\LanguageServerProtocol\TextEdit as LspTextEdit;
+use Throwable;
+
+class NameImporterResult
+{
+    /**
+     * @var bool
+     */
+    private $success;
+
+    /**
+     * @var Throwable|null
+     */
+    private $error;
+
+    /**
+     * @var array<LspTextEdit>|null
+     */
+    private $textEdits;
+
+    /**
+     * @var NameImport
+     */
+    private $nameImport;
+
+    private function __construct(
+        bool $success,
+        ?NameImport $nameImport,
+        ?array $textEdits,
+        ?Throwable $error
+    ) {
+        $this->success = $success;
+        $this->nameImport = $nameImport;
+        $this->textEdits = $textEdits;
+        $this->error = $error;
+    }
+
+    public function hasTextEdits(): bool
+    {
+        return !empty($this->textEdits);
+    }
+
+    /**
+     * @return array<LspTextEdit>|null
+     */
+    public function getTextEdits(): ?array
+    {
+        return $this->textEdits;
+    }
+
+    public function getNameImport(): ?NameImport
+    {
+        return $this->nameImport;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public function isSuccessAndHasAliasedNameImport(): bool
+    {
+        return $this->isSuccess() === true
+            && $this->getNameImport() !== null
+            && $this->getNameImport()->alias() !== null;
+    }
+
+    public function getError(): ?Throwable
+    {
+        return $this->error;
+    }
+
+    public static function createEmptyResult(): NameImporterResult
+    {
+        return new NameImporterResult(true, null, null, null);
+    }
+
+    /**
+     * @param NameImport $nameImport
+     * @param array<LspTextEdit>|null $textEdits
+     * @return NameImporterResult
+     */
+    public static function createResult(
+        NameImport $nameImport,
+        ?array $textEdits
+    ): NameImporterResult {
+        return new NameImporterResult(true, $nameImport, $textEdits, null);
+    }
+
+    public static function createErrorResult(Throwable $error): NameImporterResult
+    {
+        return new NameImporterResult(false, null, null, $error);
+    }
+}

--- a/tests/LanguageServerCodeTransform/Unit/Model/NameImporter/NameImporterTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/Model/NameImporter/NameImporterTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LanguageServerCodeTransform\Unit\Model\NameImporter;
+
+use Exception;
+use Generator;
+use Phpactor\CodeTransform\Domain\Exception\TransformException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyImportedException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport as ImportClassNameImport;
+use Phpactor\CodeTransform\Domain\Refactor\ImportName as RefactorImportName;
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
+use Phpactor\LanguageServer\Core\Workspace\Workspace;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServerProtocol\TextEdit as LspTextEdit;
+use Phpactor\TestUtils\PHPUnit\TestCase;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocumentUri;
+use Phpactor\TextDocument\TextEdit;
+use Phpactor\TextDocument\TextEdits;
+use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
+
+class NameImporterTest extends TestCase
+{
+    const EXAMPLE_CONTENT = 'hello this is some text';
+    const EXAMPLE_PATH = '/foobar.php';
+    const EXAMPLE_OFFSET = 12;
+    const EXAMPLE_PATH_URI = 'file:///foobar.php';
+
+    /**
+     * @var ObjectProphecy<RefactorImportName>
+     */
+    private $importNameProphecy;
+
+    /**
+     * @var Workspace
+     */
+    private $workspace;
+
+    /**
+     * @var TextDocumentItem
+     */
+    private $document;
+
+    /**
+     * @var array<LspTextEdit>
+     */
+    private $lspTextEdits;
+
+    /**
+     * @var TextEdits
+     */
+    private $textEdits;
+
+    /**
+     * @var SourceCode
+     */
+    private $sourceCode;
+
+    /**
+     * @var ByteOffset
+     */
+    private $byteOffset;
+
+    /**
+     * @var NameImporter
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->document = new TextDocumentItem(self::EXAMPLE_PATH_URI, 'php', 1, self::EXAMPLE_CONTENT);
+        $this->workspace = new Workspace();
+        $this->workspace->open($this->document);
+
+        $this->importNameProphecy = $this->prophesize(RefactorImportName::class);
+        $this->byteOffset = ByteOffset::fromInt(self::EXAMPLE_OFFSET);
+
+        $this->textEdits = TextEdits::one(
+            TextEdit::create(23, 6, 'huhuhu')
+        );
+
+        $this->lspTextEdits = TextEditConverter::toLspTextEdits($this->textEdits, self::EXAMPLE_CONTENT);
+
+        $this->sourceCode = SourceCode::fromStringAndPath(
+            self::EXAMPLE_CONTENT,
+            TextDocumentUri::fromString(self::EXAMPLE_PATH_URI)->path()
+        );
+
+        $this->subject = new NameImporter($this->importNameProphecy->reveal());
+    }
+
+    public function provideTestImportData(): Generator
+    {
+        yield 'function' => [
+            '\in_array',
+            'function',
+            ImportClassNameImport::forFunction('\in_array'),
+        ];
+
+        yield 'class' => [
+            self::class,
+            'class',
+            ImportClassNameImport::forClass(self::class),
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestImportData
+     */
+    public function testImport(
+        string $fqn,
+        string $importType,
+        ImportClassNameImport $importClassNameImport
+    ): void {
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            $importClassNameImport
+        )->willReturn($this->textEdits);
+
+        $result = $this->subject->__invoke(
+            $this->document,
+            self::EXAMPLE_OFFSET,
+            $importType,
+            $fqn
+        );
+
+        self::assertTrue($result->isSuccess());
+        self::assertEquals($importClassNameImport, $result->getNameImport());
+        self::assertEquals($this->lspTextEdits, $result->getTextEdits());
+        self::assertNull($result->getError());
+    }
+
+    public function testImportTransformException(): void
+    {
+        $error = new TransformException('error!!');
+
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            ImportClassNameImport::forClass(Exception::class),
+        )->willThrow($error);
+
+        $result = $this->subject->__invoke(
+            $this->document,
+            self::EXAMPLE_OFFSET,
+            'class',
+            Exception::class
+        );
+
+        self::assertFalse($result->isSuccess());
+        self::assertNull($result->getNameImport());
+        self::assertNull($result->getTextEdits());
+        self::assertSame($error, $result->getError());
+    }
+
+    public function testImportAliasAlreadyUsedException(): void
+    {
+        $import = ImportClassNameImport::forClass(Exception::class);
+        $aliasAlreadyUsedException = new AliasAlreadyUsedException($import);
+
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            $import,
+        )->willThrow($aliasAlreadyUsedException);
+
+        $aliasedNameImport = ImportClassNameImport::forClass(Exception::class, 'AliasedException');
+
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            $aliasedNameImport,
+        )->willReturn($this->textEdits);
+
+        $result = $this->subject->__invoke(
+            $this->document,
+            self::EXAMPLE_OFFSET,
+            'class',
+            Exception::class
+        );
+
+        self::assertTrue($result->isSuccess());
+        self::assertEquals($aliasedNameImport, $result->getNameImport());
+        self::assertEquals($this->lspTextEdits, $result->getTextEdits());
+        self::assertNull($result->getError());
+    }
+
+    public function testImportNameAlreadyImportedExceptionExisting(): void
+    {
+        $import = ImportClassNameImport::forClass(Exception::class);
+        $nameAlreadyImportedException = new NameAlreadyImportedException($import, Exception::class);
+
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            ImportClassNameImport::forClass(Exception::class),
+        )->willThrow($nameAlreadyImportedException);
+
+        $result = $this->subject->__invoke(
+            $this->document,
+            self::EXAMPLE_OFFSET,
+            'class',
+            Exception::class
+        );
+
+        self::assertTrue($result->isSuccess());
+        self::assertNull($result->getNameImport());
+        self::assertSame(null, $result->getTextEdits());
+        self::assertNull($result->getError());
+    }
+
+    public function testImportNameAlreadyImportedExceptionNotExisting(): void
+    {
+        $import = ImportClassNameImport::forClass(Exception::class);
+        $nameAlreadyImportedException = new NameAlreadyImportedException($import, RuntimeException::class);
+
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            $import,
+        )->willThrow($nameAlreadyImportedException);
+
+        $aliasedNameImport = ImportClassNameImport::forClass(Exception::class, 'ExceptionException');
+
+        $this->importNameProphecy->importName(
+            $this->sourceCode,
+            $this->byteOffset,
+            $aliasedNameImport,
+        )->willReturn($this->textEdits);
+
+        $result = $this->subject->__invoke(
+            $this->document,
+            self::EXAMPLE_OFFSET,
+            'class',
+            Exception::class
+        );
+
+        self::assertTrue($result->isSuccess());
+        self::assertEquals($aliasedNameImport, $result->getNameImport());
+        self::assertEquals($this->lspTextEdits, $result->getTextEdits());
+        self::assertNull($result->getError());
+    }
+}


### PR DESCRIPTION
On the journey to "replace completion import command by TextEdits". I am now providing smaller steps to avoid conflicts.

Relates to
* phpactor/phpactor#1248
* replaces phpactor/language-server-phpactor-extensions#35