### PR TITLE
Replace completion command for imports by additionalTextEdits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "~0.12.0",
         "phpunit/phpunit": "^9.0",
-        "symfony/var-dumper": "^5.1"
+        "symfony/var-dumper": "^5.1",
+        "phpactor/php-extension": "^0.1.1"
     },
     "extra": {
         "branch-alias": {

--- a/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -143,7 +143,7 @@ class LanguageServerCodeTransformExtension implements Extension
                 'name' => ImportAllUnresolvedNamesCommand::NAME
             ],
         ]);
-        
+
         $container->register(ExtractExpressionCommand::class, function (Container $container) {
             return new ExtractExpressionCommand(
                 $container->get(ClientApi::class),

--- a/lib/LanguageServerCodeTransform/LspCommand/ImportNameCommand.php
+++ b/lib/LanguageServerCodeTransform/LspCommand/ImportNameCommand.php
@@ -47,7 +47,7 @@ class ImportNameCommand implements Command
         ?string $alias = null
     ): Promise {
         $document = $this->workspace->get($uri);
-        $result = $this->nameImporter->__invoke($document, $offset, $type, $fqn, $alias);
+        $result = $this->nameImporter->__invoke($document, $offset, $type, $fqn, true, $alias);
 
         if ($result->isSuccess()) {
             if (!$result->hasTextEdits()) {

--- a/lib/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -100,7 +100,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
             $items = [];
             $isIncomplete = false;
             foreach ($suggestions as $suggestion) {
-                /** @var Suggestion $suggestion */
+                assert($suggestion instanceof Suggestion);
 
                 $name = $this->suggestionNameFormatter->format($suggestion);
                 $nameImporterResult = $this->importClassOrFunctionName($suggestion, $params);

--- a/lib/LanguageServerCompletion/LanguageServerCompletionExtension.php
+++ b/lib/LanguageServerCompletion/LanguageServerCompletionExtension.php
@@ -2,10 +2,12 @@
 
 namespace Phpactor\Extension\LanguageServerCompletion;
 
+use Microsoft\PhpParser\Parser;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\Completion\CompletionExtension;
+use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
 use Phpactor\Extension\LanguageServerCompletion\Handler\SignatureHelpHandler;
 use Phpactor\Extension\LanguageServerCompletion\Util\SuggestionNameFormatter;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
@@ -45,6 +47,8 @@ class LanguageServerCompletionExtension implements Extension
                 $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
                 $container->get(CompletionExtension::SERVICE_REGISTRY),
                 $container->get(SuggestionNameFormatter::class),
+                $container->get(NameImporter::class),
+                new Parser(),
                 $this->clientCapabilities($container)->textDocument->completion->completionItem['snippetSupport'] ?? false
             );
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => [

--- a/lib/LanguageServerCompletion/LanguageServerCompletionExtension.php
+++ b/lib/LanguageServerCompletion/LanguageServerCompletionExtension.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\Extension\LanguageServerCompletion;
 
-use Microsoft\PhpParser\Parser;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
@@ -48,7 +47,6 @@ class LanguageServerCompletionExtension implements Extension
                 $container->get(CompletionExtension::SERVICE_REGISTRY),
                 $container->get(SuggestionNameFormatter::class),
                 $container->get(NameImporter::class),
-                new Parser(),
                 $this->clientCapabilities($container)->textDocument->completion->completionItem['snippetSupport'] ?? false
             );
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => [

--- a/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportNameCommandTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/LspCommand/ImportNameCommandTest.php
@@ -72,6 +72,7 @@ class ImportNameCommandTest extends TestCase
             self::EXAMPLE_OFFSET,
             'class',
             'Foobar',
+            true,
             null
         )->willReturn(NameImporterResult::createResult(
             \Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport::forClass('Foobar'),
@@ -100,6 +101,7 @@ class ImportNameCommandTest extends TestCase
             self::EXAMPLE_OFFSET,
             'class',
             'Foobar',
+            true,
             null
         )->willReturn(NameImporterResult::createErrorResult(new TransformException('Sorry')));
 

--- a/tests/LanguageServerCodeTransform/Unit/Model/NameImporter/NameImporterTest.php
+++ b/tests/LanguageServerCodeTransform/Unit/Model/NameImporter/NameImporterTest.php
@@ -128,7 +128,8 @@ class NameImporterTest extends TestCase
             $this->document,
             self::EXAMPLE_OFFSET,
             $importType,
-            $fqn
+            $fqn,
+            true
         );
 
         self::assertTrue($result->isSuccess());
@@ -151,7 +152,8 @@ class NameImporterTest extends TestCase
             $this->document,
             self::EXAMPLE_OFFSET,
             'class',
-            Exception::class
+            Exception::class,
+            true
         );
 
         self::assertFalse($result->isSuccess());
@@ -183,7 +185,8 @@ class NameImporterTest extends TestCase
             $this->document,
             self::EXAMPLE_OFFSET,
             'class',
-            Exception::class
+            Exception::class,
+            true
         );
 
         self::assertTrue($result->isSuccess());
@@ -195,7 +198,11 @@ class NameImporterTest extends TestCase
     public function testImportNameAlreadyImportedExceptionExisting(): void
     {
         $import = ImportClassNameImport::forClass(Exception::class);
-        $nameAlreadyImportedException = new NameAlreadyImportedException($import, Exception::class);
+        $nameAlreadyImportedException = new NameAlreadyImportedException(
+            $import,
+            'Exception',
+            Exception::class
+        );
 
         $this->importNameProphecy->importName(
             $this->sourceCode,
@@ -207,11 +214,12 @@ class NameImporterTest extends TestCase
             $this->document,
             self::EXAMPLE_OFFSET,
             'class',
-            Exception::class
+            Exception::class,
+            true
         );
 
         self::assertTrue($result->isSuccess());
-        self::assertNull($result->getNameImport());
+        self::assertEquals($import, $result->getNameImport());
         self::assertSame(null, $result->getTextEdits());
         self::assertNull($result->getError());
     }
@@ -219,7 +227,11 @@ class NameImporterTest extends TestCase
     public function testImportNameAlreadyImportedExceptionNotExisting(): void
     {
         $import = ImportClassNameImport::forClass(Exception::class);
-        $nameAlreadyImportedException = new NameAlreadyImportedException($import, RuntimeException::class);
+        $nameAlreadyImportedException = new NameAlreadyImportedException(
+            $import,
+            'RuntimeException',
+            RuntimeException::class
+        );
 
         $this->importNameProphecy->importName(
             $this->sourceCode,
@@ -239,7 +251,8 @@ class NameImporterTest extends TestCase
             $this->document,
             self::EXAMPLE_OFFSET,
             'class',
-            Exception::class
+            Exception::class,
+            true
         );
 
         self::assertTrue($result->isSuccess());

--- a/tests/LanguageServerCompletion/Extension/TestExtension.php
+++ b/tests/LanguageServerCompletion/Extension/TestExtension.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Phpactor\Extension\LanguageServerCompletion\Tests\Extension;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\Extension;
+use Phpactor\FilePathResolver\Expander\ValueExpander;
+use Phpactor\FilePathResolverExtension\FilePathResolverExtension;
+use Phpactor\MapResolver\Resolver;
+
+class TestExtension implements Extension
+{
+    public function load(ContainerBuilder $container): void
+    {
+        $this->registerFilePathExpanders($container);
+    }
+
+    public function configure(Resolver $schema): void
+    {
+    }
+
+    private function registerFilePathExpanders(ContainerBuilder $container): void
+    {
+        $container->register('core.file_path_resolver.project_config_expander', function (Container $container) {
+            $path = $container->getParameter(FilePathResolverExtension::PARAM_PROJECT_ROOT) . '/.phpactor';
+            return new ValueExpander('project_config', $path);
+        }, [ FilePathResolverExtension::TAG_EXPANDER => [] ]);
+    }
+}

--- a/tests/LanguageServerCompletion/IntegrationTestCase.php
+++ b/tests/LanguageServerCompletion/IntegrationTestCase.php
@@ -5,11 +5,14 @@ namespace Phpactor\Extension\LanguageServerCompletion\Tests;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Container\PhpactorContainer;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
+use Phpactor\Extension\CodeTransform\CodeTransformExtension;
 use Phpactor\Extension\CompletionWorse\CompletionWorseExtension;
 use Phpactor\Extension\Completion\CompletionExtension;
 use Phpactor\Extension\ComposerAutoloader\ComposerAutoloaderExtension;
 use Phpactor\Extension\LanguageServerBridge\LanguageServerBridgeExtension;
+use Phpactor\Extension\LanguageServerCodeTransform\LanguageServerCodeTransformExtension;
 use Phpactor\Extension\LanguageServerCompletion\LanguageServerCompletionExtension;
+use Phpactor\Extension\LanguageServerCompletion\Tests\Extension\TestExtension;
 use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
@@ -38,17 +41,20 @@ class IntegrationTestCase extends TestCase
             LoggingExtension::class,
             CompletionExtension::class,
             LanguageServerExtension::class,
+            LanguageServerCodeTransformExtension::class,
             LanguageServerCompletionExtension::class,
             FilePathResolverExtension::class,
             ClassToFileExtension::class,
             ComposerAutoloaderExtension::class,
 
+            CodeTransformExtension::class,
             WorseReflectionExtension::class,
             CompletionWorseExtension::class,
             SourceCodeFilesystemExtension::class,
             LanguageServerWorseReflectionExtension::class,
             LanguageServerHoverExtension::class,
             PhpExtension::class,
+            TestExtension::class,
             IndexerExtension::class,
             ReferenceFinderExtension::class,
 
@@ -58,7 +64,7 @@ class IntegrationTestCase extends TestCase
             LanguageServerHoverExtension::PARAM_TEMPLATE_PATHS => [],
             IndexerExtension::PARAM_ENABLED_WATCHERS => [],
         ]);
-        
+
         $builder = $container->get(LanguageServerBuilder::class);
         $this->assertInstanceOf(LanguageServerBuilder::class, $builder);
 

--- a/tests/LanguageServerCompletion/Unit/Handler/CompletionHandlerTest.php
+++ b/tests/LanguageServerCompletion/Unit/Handler/CompletionHandlerTest.php
@@ -5,7 +5,6 @@ namespace Phpactor\Extension\LanguageServerCompletion\Tests\Unit\Handler;
 use Amp\Delayed;
 use DTL\Invoke\Invoke;
 use Generator;
-use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporterResult;
@@ -390,7 +389,6 @@ class CompletionHandlerTest extends TestCase
             $registry,
             new SuggestionNameFormatter(true),
             $this->createNameImporter($suggestions, $aliases, $importNameTextEdits),
-            new Parser(),
             $supportSnippets,
             true
         ))->build();


### PR DESCRIPTION
@dantleech maybe you could put this into your local setup and test it additionally to me since this is a critical place. Completions and imports are nearly used every day (even every minute :D - at least by me).

I did my very best for testing
- local editor setup
- test cases extended / adapted

With these changes phpactor/phpactor#1300 doesn't appear any more.