### PR TITLE
IndexerHandler: use ProgressNotifier

### DIFF
--- a/lib/LanguageServerIndexer/LanguageServerIndexerExtension.php
+++ b/lib/LanguageServerIndexer/LanguageServerIndexerExtension.php
@@ -19,6 +19,7 @@ use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Service\ServiceManager;
+use Phpactor\LanguageServer\WorkDoneProgress\ProgressNotifier;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\TextDocument\TextDocumentLocator;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -61,6 +62,7 @@ class LanguageServerIndexerExtension implements Extension
                 $container->get(Indexer::class),
                 $container->get(Watcher::class),
                 $container->get(ClientApi::class),
+                $container->get(ProgressNotifier::class),
                 $container->get(LoggingExtension::SERVICE_LOGGER),
                 $container->get(EventDispatcherInterface::class)
             );


### PR DESCRIPTION
Depends on https://github.com/phpactor/language-server-extension/pull/23

Make use of the new `ProgressNotifier` in the `IndexHandler`.

@dantleech I introduced a BC break by adding the new dependency.
Do you prefer that I handle it gracefully and trigger a depreciation if the service is not provided ?

It works on my side, the only annoying thing is that the last message disappear right away but ti's a client configuration issue IMO and it should not prevent us from using this feature on our side.