### PR TITLE
Prevent needless getDiagnostic calls

### DIFF
--- a/lib/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
@@ -72,7 +72,7 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
                 $actions[] = CodeAction::fromArray([
                     'title' =>  $title,
                     'kind' => self::KIND,
-                    'diagnostics' => $this->getDiagnostics($textDocument),
+                    'diagnostics' => $diagnostics,
                     'command' => new Command(
                         $title,
                         CreateClassCommand::NAME,
@@ -93,9 +93,7 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
      */
     private function getDiagnostics(TextDocumentItem $textDocument): array
     {
-        $node = $this->parser->parseSourceFile($textDocument->text);
-
-        if ('' !== trim($node->getFileContents())) {
+        if ('' !== trim($textDocument->text)) {
             return [];
         }
 

--- a/lib/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
+++ b/lib/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
@@ -63,23 +63,24 @@ class TransformerCodeActionPovider implements DiagnosticsProvider, CodeActionPro
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range): Promise
     {
         return call(function () use ($textDocument) {
-            if (0 === count($this->getDiagnostics($textDocument))) {
+            $diagnostics = $this->getDiagnostics($textDocument);
+            if (0 === count($diagnostics)) {
                 return [];
             }
 
             return [
                 CodeAction::fromArray([
-                'title' =>  $this->title,
-                'kind' => $this->kind(),
-                'diagnostics' => $this->getDiagnostics($textDocument),
-                'command' => new Command(
-                    $this->title,
-                    TransformCommand::NAME,
-                    [
-                        $textDocument->uri,
-                        $this->name
-                    ]
-                )
+                    'title' =>  $this->title,
+                    'kind' => $this->kind(),
+                    'diagnostics' => $diagnostics,
+                    'command' => new Command(
+                        $this->title,
+                        TransformCommand::NAME,
+                        [
+                            $textDocument->uri,
+                            $this->name
+                        ]
+                    )
                 ])
             ];
         });


### PR DESCRIPTION
Minor performance improvements in obvious places, e.g. calling `$this->getDiagnostics` in a loop.