### PR TITLE
Fix checking missing didChangeWatchedFiles capability

### DIFF
--- a/lib/LanguageServerIndexer/Watcher/LanguageServerWatcher.php
+++ b/lib/LanguageServerIndexer/Watcher/LanguageServerWatcher.php
@@ -61,7 +61,7 @@ class LanguageServerWatcher implements Watcher, WatcherProcess, ListenerProvider
         }
 
         return new Success(
-            (bool)$this->clientCapabilities->workspace['didChangeWatchedFiles'] ?? false
+            (bool)($this->clientCapabilities->workspace['didChangeWatchedFiles'] ?? false)
         );
     }
 


### PR DESCRIPTION
It only fixes casting to bool to avoid `PHP Warning:  Undefined array key "didChangeWatchedFiles"` in logs. Neovim's LSP built-in client [does not send it](https://github.com/neovim/neovim/issues/16078). 