### PR TITLE
Use TextDocumentUri to create SymbolInformation

### DIFF
--- a/lib/LanguageServerIndexer/Model/WorkspaceSymbolProvider.php
+++ b/lib/LanguageServerIndexer/Model/WorkspaceSymbolProvider.php
@@ -72,7 +72,7 @@ final class WorkspaceSymbolProvider
                 $record->fqn()->__toString(),
                 SymbolKind::CLASS_,
                 new Location(
-                    $record->filePath(),
+                    TextDocumentUri::fromString($record->filePath()),
                     new Range(
                         $this->toLspPosition($record->start(), $record->filePath()),
                         $this->toLspPosition($record->start()->add(mb_strlen($record->shortName())), $record->filePath())
@@ -86,7 +86,7 @@ final class WorkspaceSymbolProvider
                 $record->fqn()->__toString(),
                 SymbolKind::FUNCTION,
                 new Location(
-                    $record->filePath(),
+                    TextDocumentUri::fromString($record->filePath()),
                     new Range(
                         $this->toLspPosition($record->start(), $record->filePath()),
                         $this->toLspPosition($record->start()->add(mb_strlen($record->shortName())), $record->filePath())
@@ -100,7 +100,7 @@ final class WorkspaceSymbolProvider
                 $record->fqn()->__toString(),
                 SymbolKind::CONSTANT,
                 new Location(
-                    $record->filePath(),
+                    TextDocumentUri::fromString($record->filePath()),
                     new Range(
                         $this->toLspPosition($record->start(), $record->filePath()),
                         $this->toLspPosition($record->start()->add(mb_strlen($record->shortName())), $record->filePath())


### PR DESCRIPTION
It allows to use responses from `workspace/symbol` by nvim built-in LSP client. See https://github.com/neovim/neovim/blob/70db972e5fbcab39946ad8ac05472a693cf65b68/runtime/lua/vim/uri.lua#L105

